### PR TITLE
feat: update security advisory reporting

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,6 +4,6 @@ If you believe you have found a security vulnerability, I encourage you to let m
 
 I will investigate all legitimate reports and do my best to quickly fix the problem.
 
-Email [mrchriscarpenter@outlook.com](mailto:mrchriscarpenter@outlook.com) to disclose any security vulnerabilities.
+To privately disclose a security vulnerability, create a security advisory in the affected repository by visiting the `Advisories` section under the `Security` tab.
 
 :warning: **Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**


### PR DESCRIPTION
Update instructions on how to privately disclose a security vulnerability by creating a security advisory in the affected repository.